### PR TITLE
Integrates prometheus garfana

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,15 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.34</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>1.13.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.flyway.enabled=true
 spring.flyway.validate-on-migrate = true
 spring.flyway.locations = classpath:db/migration/release/v0
 spring.flyway.validateMigrationNaming=true
+
+management.metrics.tags.application=${spring.application.name}
+management.endpoints.web.exposure.include=prometheus


### PR DESCRIPTION
**Context:** Integrates and sets up prometheus grafana

**Library Versions Used:**
spring-boot-starter-actuator
micrometer-registry-prometheus: 1.13.2

**Description:**
Prometheus is used to fetch the metrics of the service and Grafana is used to display these metrics on it's UI.
This is helpful in tracing the service health.

**Setup:**
Install Prometheus:

1. docker pull prom/prometheus
2. docker run --name prometheus -d -p 9090:9090 prom/prometheus

Install Grafana

1. curl -O https://dl.grafana.com/enterprise/release/grafana-enterprise-11.2.2.darwin-amd64.tar.gz
2. tar -zxvf grafana-enterprise-11.2.2.darwin-amd64.tar.gz 
3. docker run -d -p 3000:3000 --name=grafana grafana/grafana-enterprise 

Connectivity:

1. add the required grafana and spring boot app metrics in prometheus.yaml file
    
    scrape_configs:
    
    - job_name: "prometheus"
    static_configs:
        - targets: ["localhost:9090"]
    - job_name: 'grafana_metrics'
    scrape_interval: 15s
    scrape_timeout: 5s
    static_configs:
        - targets: ['172.17.0.3:3000']
    - job_name: 'spring-boot-application'
    metrics_path: '/actuator/prometheus'
    scrape_interval: 15s # This can be adjusted based on our needs
    static_configs:
        - targets: ['192.168.1.3:8888']
2. use ‘docker inspect grafana, to get the docker ip and replace that with [[localhost](http://localhost/)](http://localhost) for above step.
3. On Grafana Dashboard, create new Grafana and JVM dashbords.

<img width="1512" alt="Screenshot 2024-10-16 at 7 16 33 PM" src="https://github.com/user-attachments/assets/879626cc-1a54-44a0-aec6-6df8b5b716ef">
    
     
<img width="1323" alt="Screenshot 2024-10-16 at 7 01 50 PM" src="https://github.com/user-attachments/assets/611740b0-55df-4c6b-9fe6-873cd55a5b59">

   
<img width="1512" alt="Screenshot 2024-10-16 at 7 12 11 PM" src="https://github.com/user-attachments/assets/5e205cfc-aabe-4da8-90f2-86175aa33892">
